### PR TITLE
perf(功能优化): 兼容多用户组的情况

### DIFF
--- a/services/iam/src/main/java/com/huaweicloud/sdk/iam/v3/model/RulesLocal.java
+++ b/services/iam/src/main/java/com/huaweicloud/sdk/iam/v3/model/RulesLocal.java
@@ -24,7 +24,7 @@ public class RulesLocal {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty(value = "groups")
 
-    private RulesLocalGroups groups;
+    private String groups;
 
     public RulesLocal withUser(RulesLocalUser user) {
         this.user = user;
@@ -78,14 +78,14 @@ public class RulesLocal {
         this.group = group;
     }
 
-    public RulesLocal withGroups(RulesLocalGroups groups) {
+    public RulesLocal withGroups(String groups) {
         this.groups = groups;
         return this;
     }
 
-    public RulesLocal withGroups(Consumer<RulesLocalGroups> groupsSetter) {
+    public RulesLocal withGroups(Consumer<String> groupsSetter) {
         if (this.groups == null) {
-            this.groups = new RulesLocalGroups();
+            this.groups = new String();
             groupsSetter.accept(this.groups);
         }
 
@@ -96,11 +96,11 @@ public class RulesLocal {
      * Get groups
      * @return groups
      */
-    public RulesLocalGroups getGroups() {
+    public String getGroups() {
         return groups;
     }
 
-    public void setGroups(RulesLocalGroups groups) {
+    public void setGroups(String groups) {
         this.groups = groups;
     }
 


### PR DESCRIPTION
我是广州人工智能算力中心开发人员，目前使用了华为的私有云HCSO,在对接用户组时遇到多用户组兼容性问题，如下： 如果联邦用户需要在IAM中属于多个用户组，身份转换规则如下所示。
以下示例表示联邦用户在IAM中的用户名称为“remote”的第一个属性值+空格+第二个属性值，即FirstName LastName。所属用户组为“remote”的第三个属性值，即Groups。
```json
[
        {

"local": [
                {
                    "user": {

"name": "{0} {1}"
                    }
                },

{
                    "groups":  "{2}"
                }

],
            "remote": [
                {

"type": "FirstName"
                },
                {

"type": "LastName"
                },
                {

"type": "Groups"
                }
            ]
        }
]

```
以上的结构无法满足接口调用的数据格式