### PR TITLE
feature(core): HttpConfig add property: ignoreHostnameVerification

### DIFF
--- a/core/src/main/java/com/huaweicloud/sdk/core/http/HttpConfig.java
+++ b/core/src/main/java/com/huaweicloud/sdk/core/http/HttpConfig.java
@@ -47,6 +47,8 @@ public class HttpConfig {
 
     private boolean ignoreSSLVerification = false;
 
+    private boolean ignoreHostnameVerification = false;
+
     private boolean ignoreRequiredValidation = false;
 
     private boolean allowRedirects = false;
@@ -114,6 +116,19 @@ public class HttpConfig {
 
     public HttpConfig withIgnoreSSLVerification(boolean ignoreSSLVerification) {
         setIgnoreSSLVerification(ignoreSSLVerification);
+        return this;
+    }
+
+    public boolean isIgnoreHostnameVerification() {
+        return this.ignoreHostnameVerification;
+    }
+
+    public void setIgnoreHostnameVerification(boolean ignoreHostnameVerification) {
+        this.ignoreHostnameVerification = ignoreHostnameVerification;
+    }
+
+    public HttpConfig withIgnoreHostnameVerification(boolean ignoreHostnameVerification) {
+        setIgnoreHostnameVerification(ignoreHostnameVerification);
         return this;
     }
 

--- a/core/src/main/java/com/huaweicloud/sdk/core/impl/DefaultHttpClient.java
+++ b/core/src/main/java/com/huaweicloud/sdk/core/impl/DefaultHttpClient.java
@@ -113,6 +113,11 @@ public class DefaultHttpClient implements HttpClient {
         if (Objects.nonNull(httpConfig.getSSLSocketFactory()) && Objects.nonNull(httpConfig.getX509TrustManager())) {
             clientBuilder.sslSocketFactory(httpConfig.getSSLSocketFactory(), httpConfig.getX509TrustManager());
         }
+        // Set certificate ignore hostname verify
+        if (httpConfig.isIgnoreHostnameVerification()) {
+            clientBuilder.hostnameVerifier(IgnoreSSLVerificationFactory.getHostnameVerifier());
+        }
+
         if (httpConfig.isIgnoreSSLVerification()) {
             clientBuilder.hostnameVerifier(IgnoreSSLVerificationFactory.getHostnameVerifier())
                     .sslSocketFactory(


### PR DESCRIPTION
In the case of self-signed HCSO, ignore the hostname validation of the certificate while maintaining server-side certificate validation