### PR TITLE
add `Host` header if not exist

### DIFF
--- a/core/src/main/java/com/huaweicloud/sdk/core/auth/AKSKSigner.java
+++ b/core/src/main/java/com/huaweicloud/sdk/core/auth/AKSKSigner.java
@@ -86,9 +86,12 @@ public class AKSKSigner implements IAKSKSigner {
 
         // Step 1: add basic headers required by V4
         URL url = request.getUrl();
-        // Step 1.1: Add Host header
-        String canonicalHost = url.getAuthority();
-        authenticationHeaders.put(Constants.HOST, canonicalHost);
+        // Step 1.1: Add Host header if not exist
+        String canonicalHost = request.getHeader(Constants.HOST);
+        if(StringUtils.isEmpty(canonicalHost){
+            canonicalHost = url.getAuthority();
+            authenticationHeaders.put(Constants.HOST, canonicalHost);
+        }
         // Step 1.2: Add X-Sdk-Date
         String dateTimeStamp = extractTimeStamp(request, authenticationHeaders);
         // Step 1.3 combine all headers


### PR DESCRIPTION
When adding a host header, do not overwrite the existing host header field.

When we make a REST call using an IP address, the Host field is passed through the Host field in the Header, and at this time, it is not possible to obtain the Host directly through the URL.